### PR TITLE
luminus/reagent additions for web dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ This is a compilation of links and resources for learning about **Clojure**, **C
  
 ## Web development / Om
 * **[weavejester/compojure on GitHub](https://github.com/weavejester/compojure)**: a truly concise routing library for Clojure web applications.
+* **[Luminus](http://www.luminusweb.net/)**: a Clojure micro-framework in style of Flask/Sinatra
 * **[swannodette/om - GitHub](https://github.com/swannodette/om)**: a **ClojureScript** library on top of Facebook's **[React library](http://facebook.github.io/react/)**. React and ClojureScript are a great match as React is particularly well suited for rendering **immutable** data structures.
 * **[A slice of React, Clojurescript and Om](http://www.lexicallyscoped.com/2013/12/25/slice-of-reactjs-and-cljs.html)**: article rewriting some React samples using **Om**
 * **[Om: Enhancing Facebook's React with Immutability](http://www.infoq.com/news/2014/01/om-react)**
+* **[Reagent](https://github.com/reagent-project/reagent-core)**: alternative ClojureSCript React wrapper
 * **[ptaoussanis/sente on GitHub](https://github.com/ptaoussanis/sente)**: powerful library for connecting a Clojure server application and a ClojureScript client side application via the WebSockets protocol. I'm using this successfully in my **[BirdWatch](https://github.com/matthiasn/birdwatch/)** project.
 * **[Compojure apps, in the style of Sinatra - Adam Bard, 09/2014](http://adambard.com/blog/sinatra-docs-in-clojure/)**: excellent introduction to Compojure, inspired by Sinatra's getting started guide.
 


### PR DESCRIPTION
Luminus provides a web template that should work for most typical apps and feel familiar for people coming from languages like Ruby and Python. The site also has lots of documentation for accomplishing common tasks.

Reagent is a great alternative to Om, even gets [endorsement from David Nolen](https://twitter.com/swannodette/status/523977012541935616), I definitely think it should be mentioned along side it.
